### PR TITLE
Only respond to F5 if editorLangId is solidity

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,12 +92,12 @@
         "command": "solidity.compile.active",
         "key": "f5",
         "mac": "f5",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus && editorLangId == 'solidity'"
     },{
         "command": "solidity.compile",
         "key": "Ctrl+f5",
         "mac": "Cmd+f5",
-        "when": "editorTextFocus"
+        "when": "editorTextFocus && editorLangId == 'solidity'"
     }
     ],
     "snippets": [


### PR DESCRIPTION
Per https://github.com/juanfranblanco/vscode-solidity/issues/20 the plugin hijacks F5.

Looked into the task runners, but I don't think it's currently possible to execute code within the extension as a part of the tasks.json. 

This patch at least only hooks to F5 and Cmd+F5 when the editor has a Solidity file open.