### PR TITLE
add "emit" to syntax

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -73,7 +73,7 @@
         },
         {
             "comment": "Langauge keywords",
-            "match": "\\b(var|import|function|enum|constant|pure|view|payable|nonpayable|if|else|for|while|do|break|continue|throw|returns?|private|public|external|inherited|storage|delete|memory|this|suicide|let|new|is|ether|wei|finney|szabo|seconds|minutes|hours|days|weeks|years\\_)\\b",
+            "match": "\\b(emit|var|import|function|enum|constant|pure|view|payable|nonpayable|if|else|for|while|do|break|continue|throw|returns?|private|public|external|inherited|storage|delete|memory|this|suicide|let|new|is|ether|wei|finney|szabo|seconds|minutes|hours|days|weeks|years\\_)\\b",
             "name": "keyword.control"
         },
         {


### PR DESCRIPTION
Invoking events without "emit" prefix is deprecated.