### PR TITLE
Solc version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4259,9 +4259,9 @@
       "integrity": "sha1-tZ8HPGn+MyVg1aEMMrqMp/KYbPs="
     },
     "solc": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.21.tgz",
-      "integrity": "sha512-8lJmimVjOG9AJOQRWS2ph4rSctPMsPGZ4H360HLs5iI+euUlt7iAvUxSLeFZZzwk0kas4Qta7HmlMXNU3yYwhw==",
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.22.tgz",
+      "integrity": "sha512-ExrPo2qqCPXo4vXEJaROHExlBdIqgV1vv5fwXMwIc19AUujlQyfyXX8AM7kOQ7xkyHqZ3rj7LJ/BHssAbHym6w==",
       "requires": {
         "fs-extra": "0.30.0",
         "memorystream": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -48,15 +48,15 @@
     "abi-code-gen": "0.0.3",
     "ajv": "^6.3.0",
     "fs-extra": "^4.0.3",
+    "nethereum-codegen": "^1.0.1",
     "read-yaml": "^1.1.0",
-    "solc": "^0.4.21",
+    "solc": "^0.4.22",
     "solhint": "^1.1.10",
     "solium": "^1.1.6",
     "solparse": "^2.2.4",
     "truffle-artifactor": "^2.1.4",
     "vscode-languageclient": "^4.0.0",
-    "vscode-languageserver": "^4.0.0",
-    "nethereum-codegen": "^1.0.1"
+    "vscode-languageserver": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^9.6.1",


### PR DESCRIPTION
Hello!

I've updated the version of solc to the latest ^0.4.22. Still, the option to use an external compiler version looks non-automateable to me (or I just don't understand how to properly configure it).

Thank you!