### PR TITLE
Syntaxes: Add natspec support + fix whitespace issues

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -5,6 +5,9 @@
     "name": "Solidity",
     "patterns": [
         {
+            "include": "#natspec"
+        },
+        {
             "include": "#comment"
         },
         {
@@ -42,6 +45,83 @@
         }
     ],
     "repository": {
+        "natspec": {
+            "patterns": [
+                {
+                    "begin": "/\\*\\*",
+                    "end": "\\*/",
+                    "name": "comment.block.documentation.solidity",
+                    "patterns": [
+                        {
+                            "include": "#natspec-tags"
+                        }
+                    ]
+                },
+                {
+                    "begin": "///",
+                    "end": "$",
+                    "name": "comment.block.documentation.solidity",
+                    "patterns": [
+                        {
+                            "include": "#natspec-tags"
+                        }
+                    ]
+                }
+            ]
+        },
+        "natspec-tags": {
+            "patterns": [
+                {
+                    "include": "#natspec-tag-title"
+                },
+                {
+                    "include": "#natspec-tag-author"
+                },
+                {
+                    "include": "#natspec-tag-notice"
+                },
+                {
+                    "include": "#natspec-tag-dev"
+                },
+                {
+                    "include": "#natspec-tag-param"
+                },
+                {
+                    "include": "#natspec-tag-return"
+                }
+            ]
+        },
+        "natspec-tag-title": {
+            "match": "(@title)\\b",
+            "name": "storage.type.title.natspec"
+        },
+        "natspec-tag-author": {
+            "match": "(@author)\\b",
+            "name": "storage.type.author.natspec"
+        },
+        "natspec-tag-notice": {
+            "match": "(@notice)\\b",
+            "name": "storage.type.dev.natspec"
+        },
+        "natspec-tag-dev": {
+            "match": "(@dev)\\b",
+            "name": "storage.type.dev.natspec"
+        },
+        "natspec-tag-param": {
+            "match": "(@param)(\\s+([A-Za-z_]\\w*))?\\b",
+            "captures": {
+                "1": {
+                    "name": "storage.type.param.natspec"
+                },
+                "3": {
+                    "name": "variable.other.natspec"
+                }
+            }
+        },
+        "natspec-tag-return": {
+            "match": "(@return)\\b",
+            "name": "storage.type.return.natspec"
+        },
         "comment": {
             "patterns": [
                 {

--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -305,12 +305,12 @@
         "declaration-contract": {
             "patterns": [
                 {
-                    "match": "\\b(contract)\\s+([A-Za-z_]\\w*)\\b",
+                    "match": "\\b(contract)(\\s+([A-Za-z_]\\w*))?\\b",
                     "captures": {
                         "1": {
                             "name": "storage.type.contract.solidity"
                         },
-                        "2": {
+                        "3": {
                             "name": "entity.name.type.contract.solidity"
                         }
                     }
@@ -322,23 +322,23 @@
             ]
         },
         "declaration-interface": {
-            "match": "\\b(interface)\\s+([A-Za-z_]\\w*)\\b",
+            "match": "\\b(interface)(\\s+([A-Za-z_]\\w*))?\\b",
             "captures": {
                 "1": {
                     "name": "storage.type.interface.solidity"
                 },
-                "2": {
+                "3": {
                     "name": "entity.name.type.interface.solidity"
                 }
             }
         },
         "declaration-library": {
-            "match": "\\b(library)\\s+([A-Za-z_]\\w*)\\b",
+            "match": "\\b(library)(\\s+([A-Za-z_]\\w*))?\\b",
             "captures": {
                 "1": {
                     "name": "storage.type.library.solidity"
                 },
-                "2": {
+                "3": {
                     "name": "entity.name.type.library.solidity"
                 }
             }
@@ -349,7 +349,7 @@
                 "1": {
                     "name": "storage.type.struct.solidity"
                 },
-                "2": {
+                "3": {
                     "name": "entity.name.type.struct.solidity"
                 }
             }
@@ -360,18 +360,18 @@
                 "1": {
                     "name": "storage.type.event.solidity"
                 },
-                "2": {
+                "3": {
                     "name": "entity.name.type.event.solidity"
                 }
             }
         },
         "declaration-constructor": {
-                "match": "\\b(constructor)(\\s+([A-Za-z_]\\w*))?\\b",
-                "captures": {
-                    "1": {
-                        "name": "storage.type.constructor.solidity"
-                    }
+            "match": "\\b(constructor)\\b",
+            "captures": {
+                "1": {
+                    "name": "storage.type.constructor.solidity"
                 }
+            }
         },
         "declaration-enum": {
             "match": "\\b(enum)(\\s+([A-Za-z_]\\w*))?\\b",
@@ -379,7 +379,7 @@
                 "1": {
                     "name": "storage.type.enum.solidity"
                 },
-                "2": {
+                "3": {
                     "name": "entity.name.type.enum.solidity"
                 }
             }
@@ -387,7 +387,7 @@
         "declaration-function": {
             "patterns": [
                 {
-                    "match": "\\b(function)(\\s+([A-Za-z_]\\w*))?\\b",
+                    "match": "\\b(function)\\s+([A-Za-z_]\\w*)\\b",
                     "captures": {
                         "1": {
                             "name": "storage.type.function.solidity"
@@ -399,7 +399,7 @@
                 },
                 {
                     "match": "\\b(private|public|internal|external|constant|pure|view|payable|nonpayable|inherited|indexed|storage|memory)\\b",
-                    "name": "storage.type.function.solidity"
+                    "name": "storage.type.mofifier.solidity"
                 }
             ]
         },
@@ -409,7 +409,7 @@
                 "1": {
                     "name": "storage.type.modifier.solidity"
                 },
-                "2": {
+                "3": {
                     "name": "entity.name.function.solidity"
                 }
             }


### PR DESCRIPTION
This PR adds support for natspec syntax highlighting.
![image](https://user-images.githubusercontent.com/17070569/41341793-e0ae90dc-6efa-11e8-81d2-e9a195cdae2c.png)

It also fixes capturing leading spaces before an identifier as in the screenshot below:
![whitespace bug](https://user-images.githubusercontent.com/17070569/41341590-605a236a-6efa-11e8-9f3e-99fe35dbb302.png)
