### PR TITLE
Fix ReturnParams Parsing from solparse

### DIFF
--- a/src/completionService.ts
+++ b/src/completionService.ts
@@ -65,6 +65,9 @@ export class CompletionService {
     public createParamsInfo(params: any): string {
         let paramsInfo = '';
         if (typeof params !== 'undefined' && params !== null) {
+            if (params.hasOwnProperty('params')) {
+                params = params.params;
+            }
             params.forEach( parameterElement => {
                const typeString = this.getTypeString(parameterElement.literal);
                 let currentParamInfo = '';


### PR DESCRIPTION
`solparse` had a [breaking change](https://github.com/duaraghav8/solparse/commit/8546241d40d6614946faa123504a655e6dafe43e) where `returnParams` is now an AST object instead of parameters array. The parameters can still be accessed from `params` field. Add check in `createParamsInfo` to see if params live inside the object instead.

Debug breakpoint to show the different object type for return params:
<img width="579" alt="screen shot 2018-07-01 at 2 28 22 pm" src="https://user-images.githubusercontent.com/4317392/42139068-c89e0ea6-7d3b-11e8-96ba-10ef4be10d02.png">

Fixed autocompletion where functions show up again:
<img width="680" alt="screen shot 2018-07-01 at 2 28 42 pm" src="https://user-images.githubusercontent.com/4317392/42139069-ca312276-7d3b-11e8-95c9-1a92d85821fc.png">

Autocompletion before:
![image](https://user-images.githubusercontent.com/4317392/42139082-fa9878ba-7d3b-11e8-931d-9c3197f1d86b.png)
