### PR TITLE
Made string syntax highlighting non-greedy

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -282,11 +282,11 @@
         "string": {
             "patterns": [
                 {
-                    "match": "\\\".*\\\"",
+                    "match": "\\\".*?\\\"",
                     "name": "string.quoted.double.solidity"
                 },
                 {
-                    "match": "\\'.*\\'",
+                    "match": "\\'.*?\\'",
                     "name": "string.quoted.single.solidity"
                 }
             ]


### PR DESCRIPTION
In the current version of the VS Code plugin, this is how syntax highlighting works for strings:

![screen shot 2018-09-24 at 3 20 45 pm](https://user-images.githubusercontent.com/1531750/45938449-7089ff80-c00d-11e8-98fe-58e5502cd6bd.png)

This is confusing because `msg.value` is not part of any string, but looks like it is with the syntax highlighting.

I'm not sure how to test this change, as I'm not set up with a development environment for the extension, but if it follows standard regex syntax, this should make the highlighting non-greedy, meaning when you have two strings on a line it'll highlight the minimum amount.

Only other issue I can see with this is the case when you escape a quote in the middle of a string which I have not handled.