### PR TITLE
fix dependencies vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -48,145 +48,6 @@
           "version": "2.5.6",
           "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz",
           "integrity": "sha1-R5Y2v6P+Ox3r1SCH8KyyBLTxnIg="
-        },
-        "fs-sync": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/fs-sync/-/fs-sync-1.0.4.tgz",
-          "integrity": "sha1-L5Tq3jGGLsCp8zocJUbfsaPz0a4=",
-          "requires": {
-            "glob": "^7.1.0",
-            "iconv-lite": "^0.4.13",
-            "lodash": "^4.16.1",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.1.4"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.2",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                  "requires": {
-                    "once": "^1.3.0",
-                    "wrappy": "1"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                },
-                "minimatch": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "requires": {
-                    "brace-expansion": "^1.0.0"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                      "requires": {
-                        "balanced-match": "^0.4.1",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "requires": {
-                    "wrappy": "1"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-                }
-              }
-            },
-            "iconv-lite": {
-              "version": "0.4.15",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-              "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-              "requires": {
-                "glob": "^7.0.5"
-              }
-            }
-          }
         }
       }
     },
@@ -1280,6 +1141,18 @@
         "through2": "^2.0.3"
       }
     },
+    "fs-sync": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/fs-sync/-/fs-sync-1.0.6.tgz",
+      "integrity": "sha512-OgbfyvmGVryknZfDXVVhua6OW8946R+AF3O2xxrCW/XFxCYZ4CO2Jrl7kYhrpjZLYvB9gxvWpLikEc9YL9HzCA==",
+      "requires": {
+        "glob": "^7.1.0",
+        "iconv-lite": "^0.4.13",
+        "lodash": "^4.16.1",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.1.4"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1320,11 +1193,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1337,15 +1212,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1448,7 +1326,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1458,6 +1337,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1470,17 +1350,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1497,6 +1380,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1569,7 +1453,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1579,6 +1464,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1684,6 +1570,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2767,9 +2654,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -4238,9 +4125,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "truffle-contract": {
           "version": "2.0.5",


### PR DESCRIPTION
According to `npm audit` there was `found 5 vulnerabilities (3 low, 2 moderate) in 1798 scanned packages`.