### PR TITLE
Correct acceptable armlet version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ajv": "^6.5.2",
     "ajv-keywords": "^3.2.0",
     "antlr4-c3": "^1.1.8",
-    "armlet": ">=0.3.1",
+    "armlet": "^1.0.0",
     "fs-extra": "^4.0.3",
     "handlebars": "^4.0.12",
     "nethereum-codegen": "^1.0.6",


### PR DESCRIPTION
We need at least armlet 1.0.0. Also, we may add more features to amlet soon, hence ^1.0.0.