### PR TITLE
Underline the full range of offending code

### DIFF
--- a/src/solErrorsToDiagnostics.ts
+++ b/src/solErrorsToDiagnostics.ts
@@ -36,16 +36,17 @@ export interface CompilerError {
         const column = parseInt(errorSplit[index + 1]);
         const severity = this.getDiagnosticSeverity(error.severity);
         const errorMessage = error.message;
+
         return {
             diagnostic: {
                 message: errorMessage,
                 range: {
                     end: {
-                        character: column,
+                        character: column + error.sourceLocation.end - error.sourceLocation.start - 1,
                         line: line - 1,
                     },
                     start: {
-                        character: column,
+                        character: column - 1,
                         line: line - 1,
                     },
                 },

--- a/src/solErrorsToDiagnostics.ts
+++ b/src/solErrorsToDiagnostics.ts
@@ -36,7 +36,6 @@ export interface CompilerError {
         const column = parseInt(errorSplit[index + 1]);
         const severity = this.getDiagnosticSeverity(error.severity);
         const errorMessage = error.message;
-
         return {
             diagnostic: {
                 message: errorMessage,


### PR DESCRIPTION
If you had an unused variable, say `uint256 nonce`, it was showing the green squiggle below only the `uint256` part which is not expected behavior.

This fix is also intended to expand the full underline for other multiword errors/warnings.