### PR TITLE
Fix enableLocalNodeCompiler type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
       "properties": {
         "solidity.enableLocalNodeCompiler": {
           "type": [
-            "bool",
-            "true"
+            "boolean",
+            "null"
           ],
           "default": null,
           "description": "If enabled (default true) and a solc version is found in the workspace node_modules, it will use this version of solc'"


### PR DESCRIPTION
There was apparently a minor mistake that prevented using the `enableLocalNodeCompiler` the type definition seemed to be wrong.

This PR intends to fix that minor typo by adding the expected accepted types.