### PR TITLE
npm script postinstall -> prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install",
+    "prepare": "node ./node_modules/vscode/bin/install",
     "test": "nyc --require ts-node/register --require source-map-support/register mocha test/**/*.spec.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## What

The npm `postinstall` script runs both on local `npm install` as well as after being installed as a dependency of someone else’s project. The `prepare` script only runs on local `npm install` (and before publishing). [[npm-scripts]](https://docs.npmjs.com/misc/scripts)

## Why

`vscode` is a devDependency, not a dependency, so if someone tries to install this package as a dependency of their own, the installation fails because `./node_modules/vscode` does not exist.

## Wait, what?

I’m the maintainer of [gatsby-remark-vscode](https://github.com/andrewbranch/gatsby-remark-vscode), a plugin for the Gatsby static site system that lets blog authors harness VS Code’s syntax highlighting engine to style their code blocks. Folks who are blogging about languages that aren’t included in VS Code’s default set of supported languages, like Solidity, can use GitHub repos like this to get syntax highlighting. Since the Visual Studio Marketplace is licensed for use only by Visual Studio products, I’m encouraging users to `npm install` any language and theme packages they need directly from GitHub (e.g. `npm install juanfranblanco/vscode-solidity`), provided the source is licensed appropriately. Unfortunately, that currently fails due to the `postinstall` script:

<img width="928" alt="image" src="https://user-images.githubusercontent.com/3277153/86545598-b5321280-bee4-11ea-8336-6740b81d7a37.png">

## See also

https://github.com/styled-components/vscode-styled-components/pull/203