### PR TITLE
remove @types/isomorphic-fetch and fix compile issue

### DIFF
--- a/README-DEVELOP.md
+++ b/README-DEVELOP.md
@@ -2,10 +2,9 @@
 **Table of Contents**
 
 - [Prerequisites...](#prerequisites)
-    - [Dependency hell](#dependency-hell)
 - [How to run code in this github repository](#how-to-run-code-in-this-github-repository)
-    - [Running](#running)
-    - [Debugging](#debugging)
+  - [Running](#running)
+  - [Debugging](#debugging)
 - [See also:](#see-also)
 
 <!-- markdown-toc end -->
@@ -21,18 +20,6 @@ You need to have installed
 
 There are a number of nodejs packages are needed, like [typescript](https://www.typescriptlang.org/), but you can get those via `npm`,
 which is described in a below [section](#how-to-run-code-in-this-github-repository).
-
-
-## Dependency hell / Current Issues
-There is a dependency on isomorphic-fetch
-if having issues compiling, replace the index.d.ts file with this
-
-```typescript
-declare namespace _fetch { }
-declare const _fetch: any;
-export = _fetch;
-```
-
 
 # How to run code in this github repository
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "solidity",
-  "version": "0.0.123",
+  "version": "0.0.124",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -69,12 +69,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true
-    },
-    "@types/isomorphic-fetch": {
-      "version": "0.0.35",
-      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
-      "integrity": "sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "yaml-js": "0.2.3"
   },
   "devDependencies": {
-    "@types/isomorphic-fetch": "0.0.35",
     "@types/node": "^11.15.3",
     "ts-node": "^7.0.1",
     "tslint": "^5.20.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es2017"
+            "es2017",
+            "DOM"
         ],
         "sourceMap": true,
         "rootDir": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es2017",
-            "DOM"
+            "es2017"
         ],
         "sourceMap": true,
         "rootDir": ".",


### PR DESCRIPTION

```
> solidity@0.0.124 compile /project/github.com/juanfranblanco/vscode-solidity
> tsc -p ./

node_modules/@types/isomorphic-fetch/index.d.ts:8:30 - error TS2552: Cannot find name 'fetch'. Did you mean '_fetch'?

8 declare const _fetch: typeof fetch;
                               ~~~~~

  node_modules/@types/isomorphic-fetch/index.d.ts:8:15
    8 declare const _fetch: typeof fetch;
                    ~~~~~~
    '_fetch' is declared here.


Found 1 error.
```