### PR TITLE
Add option to enable --stdio command line option

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -45,9 +45,9 @@ interface SoliditySettings {
 
 // import * as path from 'path';
 // Create a connection for the server
-const connection: IConnection = createConnection(
+const connection: IConnection = process.argv.length <= 2 ? createConnection(
     new IPCMessageReader(process),
-    new IPCMessageWriter(process));
+    new IPCMessageWriter(process)) : createConnection();
 
 console.log = connection.console.log.bind(connection.console);
 console.error = connection.console.error.bind(connection.console);


### PR DESCRIPTION
Hi, this is related to #282. With this change we can now run the server from the command line with `node path/to/compile/server.js [OPTIONS]` without affecting the vscode extension. This allows to run the language server as a standalone program to use with other lsp clients besides vscode.