### PR TITLE
fix parentheses highlighting

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -974,6 +974,9 @@
                         },
                         {
                             "include": "#modifier-call"
+                        },
+                        {
+                            "include": "#punctuation"
                         }
                     ]
                 },
@@ -1095,10 +1098,13 @@
             }
         },
         "function-call": {
-            "match": "\\b([A-Za-z_]\\w*)\\s*\\(",
+            "match": "\\b([A-Za-z_]\\w*)\\s*(\\()",
             "captures": {
                 "1": {
                     "name": "entity.name.function"
+                },
+                "2": {
+                    "name": "punctuation.parameters.begin"
                 }
             }
         },


### PR DESCRIPTION
Only one ')' was highlighting. I fixed it.