### PR TITLE
Add warning to README with recommendation to use npm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Solidity is the language used in Ethereum to create smart contracts, this extens
 
 # Instructions
 
+**Warning** We recommend using npm as a package manager. Other package manager like pnpm and possibly yarn cause complications with resolving solidity import paths. Until this is not solved, **please use npm**.
+
 ## Using a different version of the solidity compiler
 
 Sometimes you may want to use a different compiler than the one provided. You can find all the different versions in the solc-bin repository https://binaries.soliditylang.org/ 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Solidity is the language used in Ethereum to create smart contracts, this extens
 
 # Instructions
 
-**Warning** We recommend using npm as a package manager. Other package manager like pnpm and possibly yarn cause complications with resolving solidity import paths. Until this is not solved, **please use npm**.
+*Warning:* We recommend using npm as a package manager. Other package manager like pnpm and possibly yarn cause complications with resolving solidity import paths. Until this is not solved, **please use npm**.
 
 ## Using a different version of the solidity compiler
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Solidity is the language used in Ethereum to create smart contracts, this extens
 
 # Instructions
 
-*Warning:* We recommend using npm as a package manager. Other package manager like pnpm and possibly yarn cause complications with resolving solidity import paths. Until this is not solved, **please use npm**.
+*Warning:* We recommend using npm as a package manager. Other package managers like pnpm and possibly yarn cause complications resolving solidity import paths. Until this issue is not completely solved, **please use npm**.
 
 ## Using a different version of the solidity compiler
 


### PR DESCRIPTION
Problems with imports may be caused by using a different package manager than npm. Until this is not resolved, it may be a work around to use npm. This is issue is very pressing for some users, so I think putting a warning on top of the README makes sense.