### PR TITLE
Platform specific remappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,18 @@ If you want to use the solidity user settings for your workspace / global remapp
 Or if you want to include them in the remappings.txt file, just put the file at the root of your project folder. Note: These will override your solidity settings if included
 ![image](https://user-images.githubusercontent.com/562371/136204736-be94e8d8-1954-4981-891c-278145b27cdf.png)
 
+#### Platform specific remappings
+
+There are situations when cross-platform paths are needed, in this case you can use the ```solidity.remappingsWindows``` or ```solidity.remappingsUnix``` settings.
+
+```
+  "solidity.remappingsWindows": [
+    "@openzeppelin/=C:/Users/<USERNAME>/.brownie/packages/OpenZeppelin/openzeppelin-contracts@4.4.2"
+  ],
+  "solidity.remappingsUnix": [
+    "@openzeppelin/=/Users/<USERNAME>/.brownie/packages/OpenZeppelin/openzeppelin-contracts@4.4.2"
+  ]
+```
 
 ## Code completion
 

--- a/package.json
+++ b/package.json
@@ -197,6 +197,16 @@
           "type": "array",
           "default": [],
           "description": "Remappings to resolve contracts to local files / directories, i.e: [\"@openzeppelin/=lib/openzeppelin-contracts\",\"ds-test/=lib/ds-test/src/\"]"
+        },
+        "solidity.remappingsWindows": {
+          "type": "array",
+          "default": [],
+          "description": "Remappings to resolve contracts to local Windows files / directories, i.e: [\"@openzeppelin/=C:/lib/openzeppelin-contracts\",\"ds-test/=C:/lib/ds-test/src/\"]"
+        },
+        "solidity.remappingsUnix": {
+          "type": "array",
+          "default": [],
+          "description": "Remappings to resolve contracts to local Unix files / directories, i.e: [\"@openzeppelin/=/opt/lib/openzeppelin-contracts\",\"ds-test/=/opt/lib/ds-test/src/\"]"
         }
       }
     },

--- a/src/client/codegen.ts
+++ b/src/client/codegen.ts
@@ -94,7 +94,7 @@ function getBuildPath() {
     const packageDefaultDependenciesDirectory = vscode.workspace.getConfiguration('solidity').get<string>('packageDefaultDependenciesDirectory');
     const packageDefaultDependenciesContractsDirectory = vscode.workspace.getConfiguration('solidity').get<string>('packageDefaultDependenciesContractsDirectory');
     const rootPath = workspaceUtil.getCurrentWorkspaceRootFsPath();
-    const remappings = vscode.workspace.getConfiguration('solidity').get<string[]>('remappings');
+    const remappings = workspaceUtil.getSolidityRemappings();
     const project = initialiseProject(rootPath, packageDefaultDependenciesDirectory, packageDefaultDependenciesContractsDirectory, remappings);
     return path.join(rootPath, project.projectPackage.build_dir);
 }

--- a/src/client/compileActive.ts
+++ b/src/client/compileActive.ts
@@ -41,7 +41,7 @@ export function compileActiveContract(compiler: Compiler, overrideDefaultCompile
     const packageDefaultDependenciesDirectory = vscode.workspace.getConfiguration('solidity').get<string>('packageDefaultDependenciesDirectory');
     const packageDefaultDependenciesContractsDirectory = vscode.workspace.getConfiguration('solidity').get<string>('packageDefaultDependenciesContractsDirectory');
     const compilationOptimisation = vscode.workspace.getConfiguration('solidity').get<number>('compilerOptimization');
-    const remappings = vscode.workspace.getConfiguration('solidity').get<string[]>('remappings');
+    const remappings = workspaceUtil.getSolidityRemappings();
     const project = initialiseProject(workspaceUtil.getCurrentWorkspaceRootFsPath(), packageDefaultDependenciesDirectory, packageDefaultDependenciesContractsDirectory, remappings);
     const contract = contractsCollection.addContractAndResolveImports(contractPath, contractCode, project);
  

--- a/src/client/compileAll.ts
+++ b/src/client/compileAll.ts
@@ -20,7 +20,7 @@ export function compileAllContracts(compiler: Compiler, diagnosticCollection: vs
     const packageDefaultDependenciesDirectory = vscode.workspace.getConfiguration('solidity').get<string>('packageDefaultDependenciesDirectory');
     const packageDefaultDependenciesContractsDirectory = vscode.workspace.getConfiguration('solidity').get<string>('packageDefaultDependenciesContractsDirectory');
     const compilationOptimisation = vscode.workspace.getConfiguration('solidity').get<number>('compilerOptimization');
-    const remappings = vscode.workspace.getConfiguration('solidity').get<string[]>('remappings');
+    const remappings = workspaceUtil.getSolidityRemappings();
 
     const contractsCollection = new ContractCollection();
     const project = initialiseProject(rootPath, packageDefaultDependenciesDirectory, packageDefaultDependenciesContractsDirectory, remappings);

--- a/src/client/workspaceUtil.ts
+++ b/src/client/workspaceUtil.ts
@@ -9,3 +9,11 @@ export function getCurrentWorkspaceRootFolder(){
     const currentDocument = editor.document.uri;
     return vscode.workspace.getWorkspaceFolder(currentDocument);
 }
+
+export function getSolidityRemappings(): string[] {
+    const remappings = vscode.workspace.getConfiguration('solidity').get<string[]>('remappings');
+    if (process.platform === 'win32') {
+            return remappings.concat(vscode.workspace.getConfiguration('solidity').get<string[]>('remappingsWindows'));
+    }
+    return remappings.concat(vscode.workspace.getConfiguration('solidity').get<string[]>('remappingsUnix'));
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,6 +41,8 @@ interface SoliditySettings {
     packageDefaultDependenciesDirectory: string;
     packageDefaultDependenciesContractsDirectory: string;
     remappings: string[];
+    remappingsWindows: string[];
+    remappingsUnix: string[];
 }
 
 
@@ -303,6 +305,13 @@ connection.onDidChangeConfiguration((change) => {
     packageDefaultDependenciesContractsDirectory = settings.solidity.packageDefaultDependenciesContractsDirectory;
     packageDefaultDependenciesDirectory = settings.solidity.packageDefaultDependenciesDirectory;
     remappings = settings.solidity.remappings;
+
+    if (process.platform === 'win32') {
+        remappings = remappings.concat(settings.solidity.remappingsWindows);
+    } else {
+        remappings = remappings.concat(settings.solidity.remappingsUnix);
+    }
+
     switch (linterName(settings.solidity)) {
         case 'solhint': {
             linter = new SolhintService(rootPath, solhintDefaultRules);


### PR DESCRIPTION
Following issue #288:  https://github.com/juanfranblanco/vscode-solidity/issues/288#issuecomment-1042944301
And the discussion on Discord, I have added 2 new settings:

- `solidity.remappingsWindows`
- `solidity.remappingsUnix`

These aim to fix any cross-platform related issues caused by, for example, Brownie.
I have also updated the README file.

Please take a look and, if possible, perform a quick test on a Unix system, since I haven't been able to do it myself yet.

