### PR TITLE
Changed concat to replace functionality for remappings

### DIFF
--- a/src/client/workspaceUtil.ts
+++ b/src/client/workspaceUtil.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { replaceRemappings } from '../common/util';
 
 export function getCurrentWorkspaceRootFsPath(){
     return getCurrentWorkspaceRootFolder().uri.fsPath;
@@ -13,7 +14,7 @@ export function getCurrentWorkspaceRootFolder(){
 export function getSolidityRemappings(): string[] {
     const remappings = vscode.workspace.getConfiguration('solidity').get<string[]>('remappings');
     if (process.platform === 'win32') {
-            return remappings.concat(vscode.workspace.getConfiguration('solidity').get<string[]>('remappingsWindows'));
+        return replaceRemappings(remappings, vscode.workspace.getConfiguration('solidity').get<string[]>('remappingsWindows'));
     }
-    return remappings.concat(vscode.workspace.getConfiguration('solidity').get<string[]>('remappingsUnix'));
+    return replaceRemappings(remappings, vscode.workspace.getConfiguration('solidity').get<string[]>('remappingsUnix'));
 }

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -4,4 +4,25 @@ export function formatPath(contractPath: string) {
         return contractPath.replace(/\\/g, '/');
 }
 
-
+/**
+ * Replaces remappings in the first array with matches from the second array,
+ * then it concatenates only the unique strings from the 2 arrays.
+ *
+ * It splits the strings by '=' and checks the prefix of each element
+ * @param remappings first array of remappings strings
+ * @param replacer second array of remappings strings
+ * @returns an array containing unique remappings
+ */
+export function replaceRemappings(remappings: string[], replacer: string[]): string[] {
+        remappings.forEach(function (remapping, index) {
+                const prefix = remapping.split('=')[0];
+                for (const replaceRemapping of replacer) {
+                        const replacePrefix = replaceRemapping.split('=')[0];
+                        if (prefix === replacePrefix) {
+                                remappings[index] = replaceRemapping;
+                                break;
+                        }
+                }
+        });
+        return [...new Set([...remappings, ...replacer])];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { URI } from 'vscode-uri';
 
 import { SolidityCodeWalker } from './server/codeWalkerService';
 import { Uri } from 'vscode';
+import { replaceRemappings } from './common/util';
 
 interface Settings {
     solidity: SoliditySettings;
@@ -307,9 +308,9 @@ connection.onDidChangeConfiguration((change) => {
     remappings = settings.solidity.remappings;
 
     if (process.platform === 'win32') {
-        remappings = remappings.concat(settings.solidity.remappingsWindows);
+        remappings = replaceRemappings(remappings, settings.solidity.remappingsWindows);
     } else {
-        remappings = remappings.concat(settings.solidity.remappingsUnix);
+        remappings = replaceRemappings(remappings, settings.solidity.remappingsUnix);
     }
 
     switch (linterName(settings.solidity)) {


### PR DESCRIPTION
Following @juanfranblanco's suggestion: https://github.com/juanfranblanco/vscode-solidity/pull/322#issuecomment-1044740988

Added a replace functionality for the remappings settings.
Now it also concatenates only the unique strings from the 2 arrays.