### PR TITLE
Adds markers to folding code regions into the solidity.configuration.json file.

### DIFF
--- a/solidity.configuration.json
+++ b/solidity.configuration.json
@@ -21,5 +21,12 @@
 		["{", "}"],
 		["[", "]"],
 		["(", ")"]
-	]
+	],
+	// markers used to folding code regions
+	"folding": {
+		"markers": {
+			"start": "^\\s*//\\s*#?region\\b",
+			"end": "^\\s*//\\s*#?endregion\\b"
+		}
+	}
 }


### PR DESCRIPTION
Many developers as me use regions to organize the code. With this markers, VSCode recognizes the regions and shows the arrow icon to fold the region in .sol files.

```js
// #region MyRegionName

function MyFunction(){
	//...
}

//#endregion
```
![code-regions-screenshot](https://user-images.githubusercontent.com/9393475/154805689-f0a2c374-673b-4420-861e-c2bfffd81850.png)

