### PR TITLE
Brownie config remappings

### DIFF
--- a/src/common/projectService.ts
+++ b/src/common/projectService.ts
@@ -1,5 +1,6 @@
 'use strict';
 import * as fs from 'fs';
+import * as os from 'os'
 import * as path from 'path';
 import * as yaml from 'yaml-js';
 import {Package} from './model/package';
@@ -13,6 +14,7 @@ import { Remapping } from './model/remapping';
 
 const packageConfigFileName = 'dappFile';
 const remappingConfigFileName = 'remappings.txt';
+const brownieConfigFileName = 'brownie-config.yaml';
 // These are set using user configuration settings
 let packageDependenciesDirectory = 'lib';
 let packageDependenciesContractsDirectory = 'src';
@@ -75,18 +77,40 @@ export function initialiseProject(rootPath: string,
     return new Project(projectPackage, dependencies, packagesDirAbsolutePath, remappings);
 }
 
+function getRemappingFromBrownieConfig(rootPath:string): string[] {
+    const brownieConfigFile = path.join(rootPath, brownieConfigFileName);
+    const config = readYamlSync(brownieConfigFile);
+    let remappingsLoaded: string[];
+    try {
+        remappingsLoaded = config.compiler.solc.remappings
+    } catch (TypeError) {
+        return [];
+    }
+    const remappings = remappingsLoaded.map(i => {
+        const [alias, packageID] = i.split('=')
+        return `${alias}=${path.join(os.homedir(), ".brownie", "packages", packageID)}`;
+    });
+    return remappings
+}
+
 export function loadRemappings(rootPath:string, remappings: string[]): string[]{
+    console.log("Here")
     const remappingsFile = path.join(rootPath, remappingConfigFileName);
+    const brownieRemappings = getRemappingFromBrownieConfig(rootPath);
+    
     if(remappings == undefined) remappings = [];
     if (fs.existsSync(remappingsFile)) {
         const fileContent = fs.readFileSync(remappingsFile, 'utf8');
-        const remappingsLoaded = fileContent.split(/\r\n|\r|\n/); //split lines
+        const remappingsLoaded = fileContent.split(/\r\n|\r|\n/); //split linses
         if(remappingsLoaded){
             remappings = [];
             remappingsLoaded.forEach(element => {
                 remappings.push(element);
             });
         }
+    }
+    else if (brownieRemappings.length) {
+        remappings =  brownieRemappings;
     }
     return remappings;
 }

--- a/src/common/projectService.ts
+++ b/src/common/projectService.ts
@@ -98,10 +98,10 @@ function getRemappingsFromBrownieConfig(rootPath:string): string[] {
 
 function getRemappingsFromRemappingsFile(rootPath) {
     const remappingsFile = path.join(rootPath, remappingConfigFileName);
-    const remappings = [];
     if (fs.existsSync(remappingsFile)) {
+        const remappings = [];
         const fileContent = fs.readFileSync(remappingsFile, 'utf8');
-        const remappingsLoaded = fileContent.split(/\r\n|\r|\n/); //split linses
+        const remappingsLoaded = fileContent.split(/\r\n|\r|\n/); //split lines
         if(remappingsLoaded){
             remappingsLoaded.forEach(element => {
                 remappings.push(element);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import {
     LanguageClient,
     ServerOptions,
     TransportKind,
-  } from 'vscode-languageclient/node';
+} from 'vscode-languageclient/node';
 
 import { lintAndfixCurrentDocument } from './server/linter/soliumClientFixer';
 // tslint:disable-next-line:no-duplicate-imports
@@ -210,7 +210,7 @@ export async function activate(context: vscode.ExtensionContext) {
             // Synchronize the setting section 'solidity' to the server
             configurationSection: 'solidity',
             // Notify the server about file changes to '.sol.js files contain in the workspace (TODO node, linter)
-             fileEvents: vscode.workspace.createFileSystemWatcher('{**/remappings.txt,**/.solhint.json,**/.soliumrc.json}'),
+            fileEvents: vscode.workspace.createFileSystemWatcher('{**/remappings.txt,**/.solhint.json,**/.soliumrc.json,**/.brownie-config.yaml}'),
         },
         initializationOptions: context.extensionPath,
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,7 +210,7 @@ export async function activate(context: vscode.ExtensionContext) {
             // Synchronize the setting section 'solidity' to the server
             configurationSection: 'solidity',
             // Notify the server about file changes to '.sol.js files contain in the workspace (TODO node, linter)
-            fileEvents: vscode.workspace.createFileSystemWatcher('{**/remappings.txt,**/.solhint.json,**/.soliumrc.json,**/.brownie-config.yaml}'),
+            fileEvents: vscode.workspace.createFileSystemWatcher('{**/remappings.txt,**/.solhint.json,**/.soliumrc.json,**/brownie-config.yaml}'),
         },
         initializationOptions: context.extensionPath,
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import {
     LanguageClient,
     ServerOptions,
     TransportKind,
-} from 'vscode-languageclient/node';
+  } from 'vscode-languageclient/node';
 
 import { lintAndfixCurrentDocument } from './server/linter/soliumClientFixer';
 // tslint:disable-next-line:no-duplicate-imports


### PR DESCRIPTION
I found that relying on a separate remapping file (`remapping.txt`) for the extension is redundant when for Brownie remappings are already in place in the `brownie-config.yaml` for the compiler.

Work done in this PR:
- Added a function to read `brownie-config.yalm`
- Refactored reading the `remappings.txt` into another function
- Refactored the `loadRemappings` to just use nullish coalesce on the available options to fetch remappings
- Added the `brownie-config.yaml` to the Filesystem watcher
- Tested changes

