### PR TITLE
Add environment setting and detection. Add 'run tests' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,6 +210,21 @@
           "type": "array",
           "default": [],
           "description": "Unix Remappings to resolve contracts to local Unix files / directories (Note this overrides the generic remapping settings if the OS is Unix based), i.e: [\"@openzeppelin/=/opt/lib/openzeppelin-contracts\",\"ds-test/=/opt/lib/ds-test/src/\"]"
+        },
+        "solidity.developmentEnvironment": {
+          "type": "string",
+          "description": "Sets the development environment for the project. This is used to perform environment specific commands (like testing) and to parse output from relevant tools.",
+          "enum": [
+            "",
+            "hardhat",
+            "forge"
+          ],
+          "default": ""
+        },
+        "solidity.test.command": {
+          "type": "string",
+          "default": "",
+          "description": "Command to run to invoke tests"
         }
       }
     },
@@ -330,6 +345,10 @@
       {
         "command": "solidity.changeDefaultCompilerType",
         "title": "Solidity: Change the default workspace compiler to Remote, Local, NodeModule, Embedded"
+      },
+      {
+        "command": "solidity.runTests",
+        "title": "Solidity: Run tests"
       }
     ],
     "menus": {

--- a/src/environments/env.ts
+++ b/src/environments/env.ts
@@ -1,0 +1,21 @@
+export enum DevelopmentEnvironment {
+    Forge = 'forge',
+    Hardhat = 'hardhat',
+    None = 'none',
+    NotSet = ''
+}
+
+type ConfigDefaultAndTargetValue = {
+    default: any;
+    target: any;
+}
+
+export const defaultEnvironmentConfiguration: Partial<Record<DevelopmentEnvironment, Record<string, ConfigDefaultAndTargetValue>>> = {
+    [DevelopmentEnvironment.Forge]: {
+        'test.command': {
+            default: '',
+            target: 'forge test --silent --json'
+        },
+    }
+}
+

--- a/src/environments/env.ts
+++ b/src/environments/env.ts
@@ -2,20 +2,20 @@ export enum DevelopmentEnvironment {
     Forge = 'forge',
     Hardhat = 'hardhat',
     None = 'none',
-    NotSet = ''
+    NotSet = '',
 }
 
 type ConfigDefaultAndTargetValue = {
     default: any;
     target: any;
-}
+};
 
 export const defaultEnvironmentConfiguration: Partial<Record<DevelopmentEnvironment, Record<string, ConfigDefaultAndTargetValue>>> = {
     [DevelopmentEnvironment.Forge]: {
         'test.command': {
             default: '',
-            target: 'forge test --silent --json'
+            target: 'forge test --silent --json',
         },
-    }
-}
+    },
+};
 

--- a/src/environments/forge.ts
+++ b/src/environments/forge.ts
@@ -1,4 +1,4 @@
-import { ContractTestResults, TestResults } from "./tests";
+import { ContractTestResults, TestResults } from './tests';
 
 type forgeTestResult = {
     success: boolean,

--- a/src/environments/forge.ts
+++ b/src/environments/forge.ts
@@ -1,0 +1,36 @@
+import { ContractTestResults, TestResults } from "./tests";
+
+type forgeTestResult = {
+    success: boolean,
+    reason?: string,
+    counterexample?: null,
+    decoded_logs: string[],
+};
+
+export const parseForgeTestResults = (data: string): TestResults | null => {
+    try {
+        const parsed = JSON.parse(data);
+        const contractResults = Object.entries(parsed).map(([key, rest]: [string, any]) => {
+            const [file, contract] = key.split(':');
+            const results = Object.entries(rest.test_results).map(([name, res]: [string, forgeTestResult]) => {
+                return {
+                    name,
+                    pass: res.success,
+                    reason: res.reason,
+                    logs: res.decoded_logs,
+                };
+            });
+            const out: ContractTestResults = {
+                file,
+                contract,
+                results,
+            };
+            return out;
+        });
+        return {
+            contracts: contractResults,
+        };
+    } catch (err) {
+        return null;
+    }
+};

--- a/src/environments/tests.ts
+++ b/src/environments/tests.ts
@@ -1,6 +1,6 @@
-import { workspace } from "vscode";
-import { DevelopmentEnvironment } from "./env";
-import { parseForgeTestResults } from "./forge";
+import { workspace } from 'vscode';
+import { DevelopmentEnvironment } from './env';
+import { parseForgeTestResults } from './forge';
 
 export type TestResults = {
     contracts: ContractTestResults[];
@@ -43,8 +43,8 @@ export const parseTestResults = (data: string): TestResults | null => {
     if (devEnv === DevelopmentEnvironment.Forge) {
         return parseForgeTestResults(data);
     }
-    return null
-}
+    return null;
+};
 
 /**
  * Construct output to be printed which summarizes test results.

--- a/src/environments/tests.ts
+++ b/src/environments/tests.ts
@@ -1,0 +1,101 @@
+import { workspace } from "vscode";
+import { DevelopmentEnvironment } from "./env";
+import { parseForgeTestResults } from "./forge";
+
+export type TestResults = {
+    contracts: ContractTestResults[];
+};
+
+export type ContractTestResults = {
+    file: string;
+    contract: string;
+    results: TestResult[];
+};
+
+export type TestResult = TestResultPass | TestResultFailure;
+
+export type TestResultPass = {
+    name: string;
+    pass: true;
+    logs: string[];
+};
+
+export type TestResultFailure = {
+    name: string;
+    pass: false;
+    reason: string;
+    logs: string[];
+};
+
+export const testResultIsFailure = (r: TestResult): r is TestResultFailure => {
+    return !r.pass;
+};
+
+/**
+ * parseTestResults parses raw test result data into a format which can be interpreted
+ * by the extension.
+ * It currently only supports output from 'forge'.
+ * @param data Raw data from test command
+ * @returns TestResults, or null if unable to interpret the data
+ */
+export const parseTestResults = (data: string): TestResults | null => {
+    const devEnv = workspace.getConfiguration('solidity').get<DevelopmentEnvironment>('developmentEnvironment');
+    if (devEnv === DevelopmentEnvironment.Forge) {
+        return parseForgeTestResults(data);
+    }
+    return null
+}
+
+/**
+ * Construct output to be printed which summarizes test results.
+ * @param results Parsed test results
+ * @returns Array of lines which produce a test run summary.
+ */
+export const constructTestResultOutput = (results: TestResults): string[] =>  {
+    const lines = [];
+
+    const withFailures = results.contracts.filter(c => {
+        return c.results.filter(r => !r.pass).length > 0;
+    });
+    const hasFailures = withFailures.length > 0;
+
+    if (hasFailures) {
+        lines.push('Tests FAILED');
+        lines.push('------------');
+    }
+    results.contracts.forEach((c) => {
+        lines.push(`${c.contract} in ${c.file}:`);
+
+        const passes = c.results.filter(f => f.pass);
+        const failures = c.results.filter(f => !f.pass) as TestResultFailure[];
+
+        passes.forEach(r => {
+            lines.push(`\tPASS ${r.name}`);
+        });
+
+        failures.forEach((r) => {
+            lines.push(`\tFAIL ${r.name}`);
+            if (r.reason) {
+                lines.push(`\t REVERTED with reason: ${r.reason}`);
+            }
+
+            r.logs.forEach((log) => {
+                lines.push(`\t\t ${log}`);
+            });
+        });
+        // Add some spacing between contract results
+        lines.push('');
+    });
+
+    if (!hasFailures) {
+        lines.push('All tests passed.');
+        return lines;
+    }
+
+    lines.push('\nSummary:');
+    withFailures.forEach(f => {
+        const numFailures = f.results.filter(r => !r.pass).length;
+        lines.push(`\t${numFailures} failure(s) in ${f.contract} (${f.file})`);
+    });
+    return lines;
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!event.affectsConfiguration('solidity.developmentEnvironment')) {
             return;
         }
-        const newConfig = vscode.workspace.getConfiguration('solidity')
+        const newConfig = vscode.workspace.getConfiguration('solidity');
         const newEnv = newConfig.get<DevelopmentEnvironment>('developmentEnvironment');
         const vaulesToSet = defaultEnvironmentConfiguration[newEnv];
         if (!vaulesToSet) {
@@ -72,9 +72,8 @@ export async function activate(context: vscode.ExtensionContext) {
     }));
 
     // Detect development environment if the configuration is not already set.
-    const loadTimeConfig = vscode.workspace.getConfiguration('solidity')
+    const loadTimeConfig = vscode.workspace.getConfiguration('solidity');
     const existingDevEnv = loadTimeConfig.get<DevelopmentEnvironment>('developmentEnvironment');
-    console.log({existingDevEnv})
     if (!existingDevEnv) {
         const detectedEnv = await detectDevelopmentEnvironment();
         if (detectedEnv) {
@@ -325,7 +324,7 @@ const detectDevelopmentEnvironment = async (): Promise<string> => {
         return DevelopmentEnvironment.Hardhat;
     }
     return DevelopmentEnvironment.None;
-}
+};
 
 const getFileRootPath = (uri: vscode.Uri): string | null => {
     const folders = vscode.workspace.workspaceFolders;


### PR DESCRIPTION
This adds a `developmentEnvironment` configuration setting, with options (none, forge, hardhat). When the extension activates it attempts to automatically set this environment if it's not set.

When the environment config value changes, we attempt to set specific environment based configuration, if those are not already set. The only environment currently configured with any defaults or behaviour is `forge`.

It also adds a `runTests` command. When invoked, this runs the value in the `solidity.test.command` configuration setting, and attempts to interpret the output of the command based on the configured environment.

https://user-images.githubusercontent.com/169475/199492847-7a184507-40b8-4e0e-80a3-bb7e8462674b.mov

I'll follow this PR up with more features:
- Automatically running test when a file is saved
- Support for test coverage