### PR TITLE
Add correct processing for global brownie remappings

### DIFF
--- a/src/common/projectService.ts
+++ b/src/common/projectService.ts
@@ -92,7 +92,11 @@ function getRemappingsFromBrownieConfig(rootPath: string): string[] {
         }
         const remappings = remappingsLoaded.map(i => {
             const [alias, packageID] = i.split('=') ;
-            return `${alias}=${path.join(os.homedir(), '.brownie', 'packages', packageID)}`;
+            if (packageID.startsWith('/')) { // correct processing for imports defined with global path
+                return `${alias}=${packageID}`;
+            } else {
+                return `${alias}=${path.join(os.homedir(), '.brownie', 'packages', packageID)}`;
+            }
         });
         return remappings;
     }


### PR DESCRIPTION
Right now, every remapping specified in brownie-config.yml is recognized as remapping for something in ~/.brownie/packages. But brownie supports remapping with global pathes.

For example, if now you will specify in brownie-config.yml somethig like this: 
@openzeppelin=/home/username/oz-contracts, the vscode-solidity extension will look for it in ~/.brownie/packages/home/username/oz-contracts.

I added code that checks if the path is global, and if it is, the remapping is added to the list as it is (without ~/.brownie/packages prefix)