### PR TITLE
fix colors for strings with \" & \'

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -395,11 +395,11 @@
         "string": {
             "patterns": [
                 {
-                    "match": "\\\".*?\\\"",
+                    "match": "\\\"(?:\\\\\"|[^\\\"])*\\\"",
                     "name": "string.quoted.double"
                 },
                 {
-                    "match": "\\'.*?\\'",
+                    "match": "\\'(?:\\\\'|[^\\'])*\\'",
                     "name": "string.quoted.single"
                 }
             ]


### PR DESCRIPTION
Wrong highlighting when \" or '\ inside string with " or ' respectively.

For testing:
```solidity
        string txt1 = "";
        string txt2 = '\'jjj' + txt1 + ')\'';
        string txt3 = "\"" + txt1 + ")\"";
```