### PR TITLE
add highlight in markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "files": [
     "/dist/cli"
   ],
+  "activationEvents": [],
   "contributors": [
     "Juan Blanco"
   ],
@@ -228,6 +229,9 @@
           ".sol"
         ],
         "configuration": "./solidity.configuration.json"
+      },
+      {
+        "id": "solidity-markdown-injection"
       }
     ],
     "commands": [
@@ -572,7 +576,18 @@
         "unbalancedBracketScopes": [
           "meta.scope.case-pattern.solidity"
         ]
-      }
+      },
+      {
+        "language": "solidity-markdown-injection",
+        "scopeName": "markdown.solidity.codeblock",
+        "path": "./syntaxes/solidity-markdown-injection.json",
+        "injectTo": [
+            "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+            "meta.embedded.block.solidity": "solidity"
+        }
+    }
     ]
   }
 }

--- a/syntaxes/solidity-markdown-injection.json
+++ b/syntaxes/solidity-markdown-injection.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+      {
+          "include": "#solidity-code-block"
+      }
+  ],
+  "repository": {
+      "solidity-code-block": {
+          "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(solidity)(\\s+[^`~]*)?$)",
+          "name": "markup.fenced_code.block.markdown",
+          "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+          "beginCaptures": {
+              "3": {
+                  "name": "punctuation.definition.markdown"
+              },
+              "4": {
+                  "name": "fenced_code.block.language.markdown"
+              },
+              "5": {
+                  "name": "fenced_code.block.language.attributes.markdown"
+              }
+          },
+          "endCaptures": {
+              "3": {
+                  "name": "punctuation.definition.markdown"
+              }
+          },
+          "patterns": [
+              {
+                  "begin": "(^|\\G)(\\s*)(.*)",
+                  "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                  "contentName": "meta.embedded.block.solidity",
+                  "patterns": [
+                      {
+                          "include": "source.solidity"
+                      }
+                  ]
+              }
+          ]
+      }
+  },
+  "scopeName": "markdown.solidity.codeblock"
+}


### PR DESCRIPTION
Adds code highlighting in markdown. Markdown preview highlighting is still not working

<img width="1023" alt="Screenshot 2023-08-17 at 14 03 51" src="https://github.com/juanfranblanco/vscode-solidity/assets/1083534/a8c4cb2f-c7c5-41fc-9c48-13cc9bebc8c1">
