### PR TITLE
fix import path resolving to absolute rather than project root (#450)

### DIFF
--- a/src/common/model/sourceDocument.ts
+++ b/src/common/model/sourceDocument.ts
@@ -62,7 +62,7 @@ export class SourceDocument {
                 }
             }
         }
-        return importPath;
+        return path.resolve(this.project.projectPackage.absoluletPath, importPath);
     }
 
     public getAllImportFromPackages() {


### PR DESCRIPTION
Fixes issue #450.

**Folder Structure**
```
project/
├── src/
│   ├── MyContract.sol
└── test/
    └── MyContract.t.sol
```

**MyContract.t.sol**
```solidity
import {MyContract} from "src/MyContract.sol";
```

Currently, "Go to Definition (F12 or Ctrl + Click)" doesn't work on this import statement as it defaults to the user file system's absolute path. However, imports relative to project root do work and compile without issues by default on Hardhat, Foundry and Brownie. 

The current behaviour (resolving to absolute path) is not supported by the solidity compiler or any of them either, see [HH407](https://hardhat.org/hardhat-runner/docs/errors#HH407).