### PR TITLE
Implemented rename requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solidity",
-  "version": "0.0.180",
+  "version": "0.0.183",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solidity",
-      "version": "0.0.180",
+      "version": "0.0.183",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/src/server.ts
+++ b/src/server.ts
@@ -590,7 +590,6 @@ connection.onRenameRequest(
         RenameParams.position,
         RenameParams.newName,
         getCodeWalkerService(),
-        connection
       );
       }  
         return undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -584,11 +584,13 @@ connection.onRenameRequest(
           initCurrentProjectInWorkspaceRootFsPath(document.uri);
             
       const provider = new SolidityRenameProvider();
+      
       return provider.provideRenameEdits(
         document,
         RenameParams.position,
         RenameParams.newName,
         getCodeWalkerService(),
+        connection
       );
       }  
         return undefined;

--- a/src/server/SolidityRenameProvider.ts
+++ b/src/server/SolidityRenameProvider.ts
@@ -8,32 +8,53 @@ export class SolidityRenameProvider {
         document: TextDocument,
         position: vscode.Position,
         newName: string,
-        walker: CodeWalkerService
+        walker: CodeWalkerService,
+        connect: any
     ): vscode.WorkspaceEdit | undefined {
         const referenceProvider = new SolidityReferencesProvider();
         const references = referenceProvider.provideReferences(document, position, walker);
-
+        
+    
         if (!references || references.length === 0) {
             return undefined;
         }
-
+    
+        // Remove duplicates using a custom function
+        const uniqueReferences = this.deduplicateReferences(references);
+    
         const workspaceEdit: vscode.WorkspaceEdit = { changes: {} };
-
-        for (const reference of references) {
+    
+        for (const reference of uniqueReferences) {
             const uri = reference.uri; 
             const range = reference.range; 
-
+    
             const textEdit: vscode.TextEdit = {
                 range: range,
                 newText: newName,
             };
-
+    
             if (!workspaceEdit.changes![uri]) {
                 workspaceEdit.changes![uri] = [];
             }
             workspaceEdit.changes![uri].push(textEdit);
         }
-
+    
         return workspaceEdit;
+    }
+    
+    /**
+     * Removes duplicate references based on URI and range values
+     */
+    private deduplicateReferences(references: vscode.Location[]): vscode.Location[] {
+        const uniqueMap = new Map<string, vscode.Location>();
+        
+        for (const reference of references) {
+            const key = `${reference.uri}|${reference.range.start.line}|${reference.range.start.character}|${reference.range.end.line}|${reference.range.end.character}`;
+            
+            if (!uniqueMap.has(key)) {
+                uniqueMap.set(key, reference);
+            }
+        }
+        return Array.from(uniqueMap.values());
     }
 }

--- a/src/server/SolidityRenameProvider.ts
+++ b/src/server/SolidityRenameProvider.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { CodeWalkerService } from './parsedCodeModel/codeWalkerService';
+import { SolidityReferencesProvider } from './SolidityReferencesProvider';
+
+export class SolidityRenameProvider {
+    public provideRenameEdits(
+        document: TextDocument,
+        position: vscode.Position,
+        newName: string,
+        walker: CodeWalkerService
+    ): vscode.WorkspaceEdit | undefined {
+        const referenceProvider = new SolidityReferencesProvider();
+        const references = referenceProvider.provideReferences(document, position, walker);
+
+        if (!references || references.length === 0) {
+            return undefined;
+        }
+
+        const workspaceEdit: vscode.WorkspaceEdit = { changes: {} };
+
+        for (const reference of references) {
+            const uri = reference.uri; 
+            const range = reference.range; 
+
+            const textEdit: vscode.TextEdit = {
+                range: range,
+                newText: newName,
+            };
+
+            if (!workspaceEdit.changes![uri]) {
+                workspaceEdit.changes![uri] = [];
+            }
+            workspaceEdit.changes![uri].push(textEdit);
+        }
+
+        return workspaceEdit;
+    }
+}

--- a/src/server/SolidityRenameProvider.ts
+++ b/src/server/SolidityRenameProvider.ts
@@ -9,48 +9,73 @@ export class SolidityRenameProvider {
         position: vscode.Position,
         newName: string,
         walker: CodeWalkerService,
-        connect: any
     ): vscode.WorkspaceEdit | undefined {
         const referenceProvider = new SolidityReferencesProvider();
         const references = referenceProvider.provideReferences(document, position, walker);
-        
-    
+
         if (!references || references.length === 0) {
             return undefined;
         }
-    
-        // Remove duplicates using a custom function
+
         const uniqueReferences = this.deduplicateReferences(references);
-    
+
+        const preciseReferences = uniqueReferences.map(ref =>
+            this.getPreciseIdentifierLocation(document, ref)
+        );
+
         const workspaceEdit: vscode.WorkspaceEdit = { changes: {} };
-    
-        for (const reference of uniqueReferences) {
-            const uri = reference.uri; 
-            const range = reference.range; 
-    
+
+        for (const reference of preciseReferences) {
+            const uri = reference.uri;
+            const range = reference.range;
+
             const textEdit: vscode.TextEdit = {
                 range: range,
                 newText: newName,
             };
-    
+
             if (!workspaceEdit.changes![uri]) {
                 workspaceEdit.changes![uri] = [];
             }
             workspaceEdit.changes![uri].push(textEdit);
         }
-    
+
         return workspaceEdit;
     }
-    
-    /**
-     * Removes duplicate references based on URI and range values
-     */
+
+    private getPreciseIdentifierLocation(document: TextDocument, location: vscode.Location): vscode.Location {
+        const range = location.range;
+        const text = document.getText(range);
+
+        // exact match refex
+        const match = text.match(/(?:\w+\s+)+(\w+)(?:\s*;|\s*=|\s*\()/);
+
+        if (match && match.index !== undefined && match[1]) {
+            const identifierStart = match.index + match[0].indexOf(match[1]);
+            const identifierLength = match[1].length;
+
+            // Calculate the new range that contains only the identifier
+            const startPos = document.positionAt(document.offsetAt(range.start) + identifierStart);
+            const endPos = document.positionAt(document.offsetAt(range.start) + identifierStart + identifierLength);
+
+            return {
+                uri: location.uri,
+                range: {
+                    start: startPos,
+                    end: endPos
+                }
+            };
+        }
+
+        return location;
+    }
+
     private deduplicateReferences(references: vscode.Location[]): vscode.Location[] {
         const uniqueMap = new Map<string, vscode.Location>();
-        
+
         for (const reference of references) {
             const key = `${reference.uri}|${reference.range.start.line}|${reference.range.start.character}|${reference.range.end.line}|${reference.range.end.character}`;
-            
+
             if (!uniqueMap.has(key)) {
                 uniqueMap.set(key, reference);
             }


### PR DESCRIPTION
Im trying to implement a MVP for enabling rename requests. 

I struggled a lot with the implementation as there are numerous quirks with current reference provider perhaps these could be solved in another PR. Here is what i found in the reference provider:

1. Returns duplicates for each reference.

2. Returns two locations for some references for example:
Top level storage variables:
`IExample public immutable Example;`
The reference provider will return both location for `Example` and the entire line `IExample public immutable Example;`, this causes overlapping references which causes errors in the rename provider.

Therefore in this PR, I had to remove duplicate locations and implement an 'exact' location finder for a references (which doesnt work in all scenarios). These arent the cleanest solutions and perhaps this should be the default behaviours of the reference provider itself. 


Issues:

Renaming still replaces the entire 'reference' and not the exact match of the word

