### PR TITLE
fix: mapping and function parameter highlighting

### DIFF
--- a/syntaxes/solidity.json
+++ b/syntaxes/solidity.json
@@ -949,6 +949,15 @@
                     "include": "#type-primitive"
                 },
                 {
+                    "include": "#declaration-storage-mapping"
+                },
+                {
+                    "include": "#type-function"
+                },
+                {
+                    "include": "#type-modifier-access"
+                },
+                {
                     "include": "#type-modifier-extended-scope"
                 },
                 {
@@ -1097,13 +1106,13 @@
         "declaration-storage-mapping": {
             "patterns": [
                 {
-                    "begin": "\\b(mapping)\\b",
+                    "begin": "\\b(mapping)\\s*\\(",
                     "beginCaptures": {
                         "1": {
                             "name": "storage.type.mapping"
                         }
                     },
-                    "end": "(?=\\))",
+                    "end": "\\)",
                     "patterns": [
                         {
                             "include": "#declaration-storage-mapping"
@@ -1112,16 +1121,36 @@
                             "include": "#type-primitive"
                         },
                         {
-                            "include": "#punctuation"
+                            "include": "#operator"
                         },
                         {
-                            "include": "#operator"
+                            "include": "#punctuation"
                         }
                     ]
                 },
                 {
                     "match": "\\b(mapping)\\b",
                     "name": "storage.type.mapping"
+                }
+            ]
+        },
+        "type-function": {
+            "begin": "\\b(function)\\s*\\(",
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.function"
+                }
+            },
+            "end": "\\)",
+            "patterns": [
+                {
+                    "include": "#type-function"
+                },
+                {
+                    "include": "#type-primitive"
+                },
+                {
+                    "include": "#punctuation"
                 }
             ]
         },


### PR DESCRIPTION
Fixes https://github.com/juanfranblanco/vscode-solidity/issues/496

### 1. Fixes `declaration-storage-mapping` (L1115)

```
"end": "\\)"  // Changed from "(?=\\))" to actually consume the closing parenthesis
```

This allows nested mappings like `mapping(address => mapping(uint256 => bool))` to work correctly.

### 2. Adds `type-function` pattern (L1137-1156)

New pattern to handle function type parameters like:
```
function(address, uint256) external callback
```

### 3. Updates `declaration-function-parameters` (L952, L955, L958)

Adds three `include`s to recognize mapping types in parameters, function types in parameters, and visibility modifiers (`external`, `internal`, etc.).